### PR TITLE
SIGTERM support for graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,17 @@ Kill multiple processes listening on ports 8045, 8046, and 8080:
 ```sh
 killport 8045 8046 8080
 ```
+
+Kill processes with specified signal:
+
+```sh
+killport -s sigterm 8080
+```
+
 ### Flags
+
+-s, --sigspec
+    Specify a signal name to be sent. (e.g. sigterm)
 
 -v, --verbose
     Increase the verbosity level. Use multiple times for more detailed output.

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ killport 8045 8046 8080
 Kill processes with specified signal:
 
 ```sh
-killport -s sigterm 8080
+killport -s sigkill 8080
 ```
 
 ### Flags
 
 -s, --signal
-    Specify a signal name to be sent. (e.g. sigterm)
+    Specify a signal name to be sent. (e.g. sigkill)
 
 -v, --verbose
     Increase the verbosity level. Use multiple times for more detailed output.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ killport -s sigterm 8080
 
 ### Flags
 
--s, --sigspec
+-s, --signal
     Specify a signal name to be sent. (e.g. sigterm)
 
 -v, --verbose

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -81,7 +81,10 @@ fn find_target_inodes(port: u16) -> Vec<u64> {
 ///
 /// * `target_inode` - A u64 value representing the target inode.
 /// * `signal` - A enum value representing the signal type.
-fn kill_processes_by_inode(target_inode: u64, signal: KillPortSignalOptions) -> Result<bool, Error> {
+fn kill_processes_by_inode(
+    target_inode: u64,
+    signal: KillPortSignalOptions,
+) -> Result<bool, Error> {
     let processes = procfs::process::all_processes().unwrap();
     let mut killed_any = false;
 
@@ -135,7 +138,10 @@ fn kill_processes_by_inode(target_inode: u64, signal: KillPortSignalOptions) -> 
 ///
 /// * `pid` - An i32 value representing the process ID.
 /// * `signal` - A enum value representing the signal type.
-fn kill_process_and_children(pid: i32, signal: KillPortSignalOptions) -> Result<(), std::io::Error> {
+fn kill_process_and_children(
+    pid: i32,
+    signal: KillPortSignalOptions,
+) -> Result<(), std::io::Error> {
     let mut children_pids = Vec::new();
     collect_child_pids(pid, &mut children_pids)?;
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,4 +1,4 @@
-use crate::KillPortSigSpecOptions;
+use crate::KillPortSignalOptions;
 
 use log::{debug, info, warn};
 use nix::sys::signal::{kill, Signal};
@@ -18,7 +18,7 @@ use std::path::Path;
 ///
 /// * `port` - A u16 value representing the port number.
 /// * `signal` - A enum value representing the signal type.
-pub fn kill_processes_by_port(port: u16, signal: KillPortSigSpecOptions) -> Result<bool, Error> {
+pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Result<bool, Error> {
     let mut killed_any = false;
 
     let target_inodes = find_target_inodes(port);
@@ -81,7 +81,7 @@ fn find_target_inodes(port: u16) -> Vec<u64> {
 ///
 /// * `target_inode` - A u64 value representing the target inode.
 /// * `signal` - A enum value representing the signal type.
-fn kill_processes_by_inode(target_inode: u64, signal: KillPortSigSpecOptions) -> Result<bool, Error> {
+fn kill_processes_by_inode(target_inode: u64, signal: KillPortSignalOptions) -> Result<bool, Error> {
     let processes = procfs::process::all_processes().unwrap();
     let mut killed_any = false;
 
@@ -135,7 +135,7 @@ fn kill_processes_by_inode(target_inode: u64, signal: KillPortSigSpecOptions) ->
 ///
 /// * `pid` - An i32 value representing the process ID.
 /// * `signal` - A enum value representing the signal type.
-fn kill_process_and_children(pid: i32, signal: KillPortSigSpecOptions) -> Result<(), std::io::Error> {
+fn kill_process_and_children(pid: i32, signal: KillPortSignalOptions) -> Result<(), std::io::Error> {
     let mut children_pids = Vec::new();
     collect_child_pids(pid, &mut children_pids)?;
 
@@ -176,13 +176,13 @@ fn collect_child_pids(pid: i32, child_pids: &mut Vec<i32>) -> Result<(), std::io
 ///
 /// * `pid` - An i32 value representing the process ID.
 /// * `signal` - A enum value representing the signal type.
-fn kill_process(pid: i32, signal: KillPortSigSpecOptions) -> Result<(), std::io::Error> {
+fn kill_process(pid: i32, signal: KillPortSignalOptions) -> Result<(), std::io::Error> {
     info!("Killing process with PID {}", pid);
     let pid = Pid::from_raw(pid);
 
     let system_signal = match signal {
-        KillPortSigSpecOptions::SIGKILL => Signal::SIGKILL,
-        KillPortSigSpecOptions::SIGTERM => Signal::SIGTERM,
+        KillPortSignalOptions::SIGKILL => Signal::SIGKILL,
+        KillPortSignalOptions::SIGTERM => Signal::SIGTERM,
     };
     kill(pid, system_signal).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,4 @@
-use crate::KillPortSigSpecOptions;
+use crate::KillPortSignalOptions;
 
 use libproc::libproc::file_info::pidfdinfo;
 use libproc::libproc::file_info::{ListFDs, ProcFDType};
@@ -41,7 +41,7 @@ fn collect_proc() -> Vec<TaskAllInfo> {
 /// # Returns
 ///
 /// A `Result` containing a boolean value. If true, at least one process was killed; otherwise, false.
-pub fn kill_processes_by_port(port: u16, signal: KillPortSigSpecOptions) -> Result<bool, io::Error> {
+pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Result<bool, io::Error> {
     let process_infos = collect_proc();
     let mut killed = false;
 
@@ -94,8 +94,8 @@ pub fn kill_processes_by_port(port: u16, signal: KillPortSigSpecOptions) -> Resu
             } else {
                 info!("Killing process with PID {}", pid);
                 let system_signal = match signal {
-                    KillPortSigSpecOptions::SIGKILL => Signal::SIGKILL,
-                    KillPortSigSpecOptions::SIGTERM => Signal::SIGTERM,
+                    KillPortSignalOptions::SIGKILL => Signal::SIGKILL,
+                    KillPortSignalOptions::SIGTERM => Signal::SIGTERM,
                 };
                 match signal::kill(pid, system_signal) {
                     Ok(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ struct KillPortArgs {
         short = 's',
         name = "SIG",
         help = "SIG is a signal name",
-        default_value = "sigkill"
+        default_value = "sigterm"
     )]
     signal: KillPortSignalOptions,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,16 @@ struct KillPortArgs {
     )]
     ports: Vec<u16>,
 
+    /// An option to specify the type of signal to be sent.
+    #[arg(
+        long,
+        short = 's',
+        name = "SIG",
+        help = "SIG is a signal name",
+        default_value = "sigkill"
+    )]
+    sigspec: KillPortSigSpecOptions,
+
     /// A verbosity flag to control the level of logging output.
     #[command(flatten)]
     verbose: Verbosity<WarnLevel>,
@@ -67,9 +77,13 @@ fn main() {
         .filter_level(log_level)
         .init();
 
+    // Determine a signal to be sent.
+    // If an option for signal number is added, we can determine a signal to be sent by signal number.
+    let signal = args.sigspec;
+
     // Attempt to kill processes listening on specified ports
     for port in args.ports {
-        match kill_processes_by_port(port) {
+        match kill_processes_by_port(port, signal) {
             Ok(killed) => {
                 if killed {
                     println!("Successfully killed process listening on port {}", port);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,10 +14,18 @@ use linux::kill_processes_by_port;
 #[cfg(target_os = "macos")]
 use macos::kill_processes_by_port;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 use log::error;
 use std::process::exit;
+
+/// The `KillPortArgs` struct is used to parse command-line arguments for the
+/// `killport` utility.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum KillPortSigSpecOptions {
+    SIGKILL,
+    SIGTERM,
+}
 
 /// The `KillPortArgs` struct is used to parse command-line arguments for the
 /// `killport` utility.

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,9 @@ use clap_verbosity_flag::{Verbosity, WarnLevel};
 use log::error;
 use std::process::exit;
 
-/// The `KillPortArgs` struct is used to parse command-line arguments for the
-/// `killport` utility.
+/// The `KillPortSignalOptions` enum is used to specify signal types on the command-line arguments.
 #[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum KillPortSigSpecOptions {
+pub enum KillPortSignalOptions {
     SIGKILL,
     SIGTERM,
 }
@@ -48,7 +47,7 @@ struct KillPortArgs {
         help = "SIG is a signal name",
         default_value = "sigkill"
     )]
-    sigspec: KillPortSigSpecOptions,
+    signal: KillPortSignalOptions,
 
     /// A verbosity flag to control the level of logging output.
     #[command(flatten)]
@@ -79,7 +78,7 @@ fn main() {
 
     // Determine a signal to be sent.
     // If an option for signal number is added, we can determine a signal to be sent by signal number.
-    let signal = args.sigspec;
+    let signal = args.signal;
 
     // Attempt to kill processes listening on specified ports
     for port in args.ports {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -35,6 +35,7 @@ fn test_killport() {
 
     assert!(status.success(), "Mock process compilation failed");
 
+    // Test killport execution without options
     let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
         .spawn()
         .expect("Failed to run the mock process");
@@ -42,6 +43,23 @@ fn test_killport() {
     // Test killport command
     let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
     cmd.arg("8080")
+        .assert()
+        .success()
+        .stdout("Successfully killed process listening on port 8080\n");
+
+    // Cleanup: Terminate the mock process (if still running).
+    let _ = mock_process.kill();
+
+    // Test killport execution with -s option
+    let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
+        .spawn()
+        .expect("Failed to run the mock process");
+
+    // Test killport command with specifying a signal name
+    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
+    cmd.arg("8080")
+        .arg("-s")
+        .arg("sigterm")
         .assert()
         .success()
         .stdout("Successfully killed process listening on port 8080\n");


### PR DESCRIPTION

**Description of the changes**
1. **Additional option to specify a signal type**: I have added an option to specify signal types to killport cli. (like a traditional unix `kill` command)
- We can set `-s`/ `--signal` option to specify signal type.
- e.g. `killport -s sigterm 8080`
2. **SIGTERM support**: We can specify `-s sigterm` option for graceful shutdown.

**Related issue(s)**
<!-- If` this PR is related to an existing issue, please link to it using the `Fixes #issue_number` or `Closes #issue_number` syntax. -->

This PR is related to the issue https://github.com/jkfran/killport/issues/8.
But this is not completely support for all signal types.

**Type of change**
Please select one or multiple of the following options:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup (refactoring or improving code quality)
- [ ] Documentation update (adding or updating documentation, updating README)

**Checklist:**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional information**
Add any other information or screenshots about the pull request here.
