### PR TITLE
Stop docker containers on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +112,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "bindgen"
 version = "0.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +171,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
+name = "bollard"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af254ed2da4936ef73309e9597180558821cb16ae9bba4cb24ce6b612d8d80ed"
+dependencies = [
+ "base64 0.21.2",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602bda35f33aeb571cef387dcd4042c643a8bf689d8aaac2cc47ea24cb7bc7e0"
+dependencies = [
+ "serde",
+ "serde_with",
+]
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +231,12 @@ name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
@@ -187,6 +268,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
+ "serde",
  "winapi",
 ]
 
@@ -353,10 +435,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
@@ -377,10 +557,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -403,6 +654,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -437,6 +709,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,6 +728,7 @@ name = "killport"
 version = "0.9.1"
 dependencies = [
  "assert_cmd",
+ "bollard",
  "clap",
  "clap-verbosity-flag",
  "env_logger",
@@ -459,6 +738,7 @@ dependencies = [
  "nix",
  "procfs",
  "tempfile",
+ "tokio",
  "windows-sys 0.48.0",
 ]
 
@@ -550,6 +830,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "nix"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +874,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +903,38 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -700,6 +1042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,16 +1081,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
 name = "serde"
 version = "1.0.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d25439cd7397d044e2748a6fe2432b5e85db703d6d097bd014b3c0ad1ebff0b"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23f7ade6f110613c0d63858ddb8b94c1041f550eab58a16b371bdf2c9c80ab4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e168eaaf71e8f9bd6037feb05190485708e019f4fd87d161b3c0a0d37daf85e5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ff71d2c147a7b57362cead5e22f772cd52f6ab31cfcd9edcd7f6aeb2a0afbe"
+dependencies = [
+ "base64 0.13.1",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "time",
+]
 
 [[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -807,10 +1243,161 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
+name = "thiserror"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+dependencies = [
+ "itoa",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+dependencies = [
+ "autocfg",
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "url"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -826,6 +1413,21 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "4.3.19", features = ["derive"] }
 nix = "0.26.2"
 bollard = "0.14.0"
 tokio = "1.28.0"
-anyhow = "1.0.71"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.15.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ env_logger = "0.10.0"
 clap-verbosity-flag = "2.0.1"
 clap = { version = "4.3.19", features = ["derive"] }
 nix = "0.26.2"
+bollard = "0.14.0"
+tokio = "1.28.0"
+anyhow = "1.0.71"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.15.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap-verbosity-flag = "2.0.1"
 clap = { version = "4.3.19", features = ["derive"] }
 nix = "0.26.2"
 bollard = "0.14.0"
-tokio = "1.28.0"
+tokio = "1.29.1"
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 procfs = "0.15.1"

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@
 ## Features
 
 - Kill processes by port number
+- Kill docker container by port number
 - Supports multiple port numbers
 - Verbosity control
 - Works on Linux, macOS and Windows
+- Serveral signal types (SIGTERM, SIGKILL)
 
 ## Installation
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -90,14 +90,11 @@ impl Killable for NativeProcess {
     ///
     /// * `signal` - A enum value representing the signal type.
     fn kill(&self, signal: KillPortSignalOptions) -> Result<bool> {
-        let mut killed_any = false;
+        if let Err(err) = Self::kill_process_and_children(self.pid, signal) {
+            return Err(err);
+        }
 
-        match Self::kill_process_and_children(self.pid, signal) {
-            Ok(_) => killed_any = true,
-            Err(err) => return Err(err),
-        };
-
-        Ok(killed_any)
+        Ok(true)
     }
 }
 
@@ -142,14 +139,11 @@ impl Killable for DockerContainer {
     ///
     /// * `signal` - A enum value representing the signal type.
     fn kill(&self, signal: KillPortSignalOptions) -> Result<bool> {
-        let mut killed_any = false;
+        if let Err(err) = Self::kill_container(&self.name, signal) {
+            return Err(err);
+        }
 
-        match Self::kill_container(&self.name, signal) {
-            Ok(_) => killed_any = true,
-            Err(err) => return Err(err),
-        };
-
-        Ok(killed_any)
+        Ok(true)
     }
 }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -315,8 +315,8 @@ fn find_target_containers(port: u16) -> Vec<DockerContainer> {
 
         let mut filters = HashMap::new();
         filters.insert("publish".to_string(), vec![port.to_string()]);
+        filters.insert("status".to_string(), vec!["running".to_string()]);
         let options = ListContainersOptions {
-            all: true,
             filters,
             ..Default::default()
         };
@@ -337,6 +337,10 @@ fn find_target_containers(port: u16) -> Vec<DockerContainer> {
                 target_containers.push(DockerContainer {
                     name: container_name.to_string(),
                 });
+
+                // Break immediately when we added a container bound to target port,
+                // because the ports vec has both of IPv4 and IPv6 port mapping information about a same container.
+                break;
             }
         }
     });

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -27,7 +27,7 @@ impl NativeProcess {
     ///
     /// # Arguments
     ///
-    /// * `pid` - An i32 value representing the process ID.
+    /// * `pid` - An Pid struct representing the process ID.
     /// * `signal` - A enum value representing the signal type.
     fn kill_process(pid: Pid, signal: KillPortSignalOptions) -> Result<()> {
         info!("Killing process with PID {}", pid);
@@ -44,7 +44,7 @@ impl NativeProcess {
     ///
     /// # Arguments
     ///
-    /// * `pid` - An i32 value representing the process ID.
+    /// * `pid` - An Pid struct representing the process ID.
     /// * `signal` - A enum value representing the signal type.
     fn kill_process_and_children(pid: Pid, signal: KillPortSignalOptions) -> Result<()> {
         let mut children_pids = Vec::new();
@@ -64,7 +64,7 @@ impl NativeProcess {
     ///
     /// # Arguments
     ///
-    /// * `pid` - An i32 value representing the process ID.
+    /// * `pid` - An Pid struct representing the process ID.
     /// * `child_pids` - A mutable reference to a `Vec<i32>` where the child PIDs will be stored.
     fn collect_child_pids(pid: Pid, child_pids: &mut Vec<Pid>) -> Result<()> {
         let processes = procfs::process::all_processes().unwrap();
@@ -84,7 +84,7 @@ impl NativeProcess {
 }
 
 impl Killable for NativeProcess {
-    /// Kill the linux native process.
+    /// Entry point to kill the linux native process.
     ///
     /// # Arguments
     ///
@@ -108,6 +108,12 @@ struct DockerContainer {
 }
 
 impl DockerContainer {
+    /// Kill the docker container.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A container name.
+    /// * `signal` - A enum value representing the signal type.
     fn kill_container(name: &String, signal: KillPortSignalOptions) -> Result<()> {
         info!("Killing container with name {}", name);
 
@@ -130,6 +136,11 @@ impl DockerContainer {
 }
 
 impl Killable for DockerContainer {
+    /// Entry point to kill the docker containers.
+    ///
+    /// # Arguments
+    ///
+    /// * `signal` - A enum value representing the signal type.
     fn kill(&self, signal: KillPortSignalOptions) -> Result<bool> {
         let mut killed_any = false;
 
@@ -294,9 +305,9 @@ fn find_target_processes(inodes: Vec<u64>) -> Vec<NativeProcess> {
     target_pids
 }
 
-/// Finds the inodes associated with the specified `port`.
+/// Finds the docker containers associated with the specified `port`.
 ///
-/// Returns a `Vec` of inodes for both IPv4 and IPv6 connections.
+/// Returns a `Vec` of docker containers.
 ///
 /// # Arguments
 ///

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -36,8 +36,7 @@ impl NativeProcess {
             KillPortSignalOptions::SIGKILL => Signal::SIGKILL,
             KillPortSignalOptions::SIGTERM => Signal::SIGTERM,
         };
-        kill(pid, system_signal)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+        kill(pid, system_signal).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
     }
 
     /// Recursively kills the process with the specified `pid` and its children.
@@ -72,10 +71,10 @@ impl NativeProcess {
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
         for p in processes {
-            let process = p
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let process = p.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
-            let stat = process.stat()
+            let stat = process
+                .stat()
                 .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
             if stat.ppid == pid.as_raw() {
                 let pid = Pid::from_raw(process.pid);
@@ -285,13 +284,11 @@ fn find_target_processes(inodes: Vec<u64>) -> Result<Vec<NativeProcess>, Error> 
         let processes = procfs::process::all_processes()
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
         for p in processes {
-            let process = p
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+            let process = p.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
             if let Ok(fds) = process.fd() {
                 for fd in fds {
-                    let fd = fd
-                        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                    let fd = fd.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
 
                     if let FDTarget::Socket(sock_inode) = fd.target {
                         if inode == sock_inode {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -40,10 +40,16 @@ fn collect_proc() -> Vec<TaskAllInfo> {
 ///
 /// # Returns
 ///
-/// A `Result` containing a boolean value. If true, at least one process was killed; otherwise, false.
-pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Result<bool, io::Error> {
+/// A `Result` containing a tuple. The first element is a boolean indicating if
+/// at least one process was killed (true if yes, false otherwise). The second
+/// element is a string indicating the type of the killed entity.
+pub fn kill_processes_by_port(
+    port: u16,
+    signal: KillPortSignalOptions,
+) -> Result<(bool, String), io::Error> {
     let process_infos = collect_proc();
     let mut killed = false;
+    let killable_type = String::from("process"); // assuming all are Processes for now
 
     for task in process_infos {
         let pid = task.pbsd.pbi_pid as i32;
@@ -112,5 +118,5 @@ pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Resul
         }
     }
 
-    Ok(killed)
+    Ok((killed, killable_type))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ struct KillPortArgs {
     /// A list of port numbers to kill processes on.
     #[arg(
         name = "ports",
-        help = "The list of port numbers to kill processes on",
+        help = "The list of port numbers to kill processes or containers on",
         required = true
     )]
     ports: Vec<u16>,
@@ -87,11 +87,14 @@ fn main() {
     // Attempt to kill processes listening on specified ports
     for port in args.ports {
         match kill_processes_by_port(port, signal) {
-            Ok(killed) => {
+            Ok((killed, killable_type)) => {
                 if killed {
-                    println!("Successfully killed process listening on port {}", port);
+                    println!(
+                        "Successfully killed {} listening on port {}",
+                        killable_type, port
+                    );
                 } else {
-                    println!("No processes found using port {}", port);
+                    println!("No services found using port {}", port);
                 }
             }
             Err(err) => {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -31,14 +31,20 @@ use windows_sys::Win32::{
 
 /// Attempts to kill processes listening on the specified `port`.
 ///
-/// Returns a `Result` with `true` if any processes were killed, `false` if no
-/// processes were found listening on the port, and an `Error` if the operation
-/// failed or the platform is unsupported.
-///
 /// # Arguments
 ///
 /// * `port` - A u16 value representing the port number.
-pub fn kill_processes_by_port(port: u16, _: KillPortSignalOptions) -> Result<bool> {
+///
+/// # Returns
+///
+/// A `Result` containing a tuple. The first element is a boolean indicating if
+/// at least one process was killed (true if yes, false otherwise). The second
+/// element is a string indicating the type of the killed entity. An `Error` is
+/// returned if the operation failed or the platform is unsupported.
+pub fn kill_processes_by_port(
+    port: u16,
+    _: KillPortSignalOptions,
+) -> Result<(bool, String), Error> {
     let mut pids: HashSet<u32> = HashSet::new();
     unsafe {
         // Find processes in the TCP IPv4 table
@@ -55,7 +61,7 @@ pub fn kill_processes_by_port(port: u16, _: KillPortSignalOptions) -> Result<boo
 
         // Nothing was found
         if pids.is_empty() {
-            return Ok(false);
+            return Ok((false, "None".to_string()));
         }
 
         // Collect parents of the PIDs
@@ -66,7 +72,7 @@ pub fn kill_processes_by_port(port: u16, _: KillPortSignalOptions) -> Result<boo
         }
 
         // Something had to have been killed to reach here
-        Ok(true)
+        Ok((true, "process".to_string()))
     }
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -67,3 +67,23 @@ fn test_killport() {
     // Cleanup: Terminate the mock process (if still running).
     let _ = mock_process.kill();
 }
+
+
+#[test]
+fn test_killport_for_docker() {
+    // Run a mock container in the background
+    let mut mock_process = std::process::Command::new("docker")
+        .args(["run", "-d", "--name", "test", "--rm", "-p", "8081:80", "nginx:latest"])
+        .spawn()
+        .expect("Failed to run the mock container process");
+
+    // Test killport command with specifying a port is bound for docker container
+    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
+    cmd.arg("8081")
+        .assert()
+        .success()
+        .stdout("Successfully killed process listening on port 8081\n");
+
+    // Cleanup: Terminate the mock process (if still running).
+    let _ = mock_process.kill();
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -68,35 +68,3 @@ fn test_killport() {
     // Cleanup: Terminate the mock process (if still running).
     let _ = mock_process.kill();
 }
-
-#[test]
-fn test_killport_for_docker() {
-    // Run a mock container in the background
-    let mut mock_process = std::process::Command::new("docker")
-        .args([
-            "run",
-            "-d",
-            "--name",
-            "test",
-            "--rm",
-            "-p",
-            "8081:80",
-            "nginx:latest",
-        ])
-        .spawn()
-        .expect("Failed to run the mock container process");
-
-    // FIXME: We should wait a few millseconds for the container is running definitely.
-    let wait = time::Duration::from_millis(500);
-    thread::sleep(wait);
-
-    // Test killport command with specifying a port is bound for docker container
-    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
-    cmd.arg("8081")
-        .assert()
-        .success()
-        .stdout("Successfully killed process listening on port 8081\n");
-
-    // Cleanup: Terminate the mock process (if still running).
-    let _ = mock_process.kill();
-}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -68,12 +68,20 @@ fn test_killport() {
     let _ = mock_process.kill();
 }
 
-
 #[test]
 fn test_killport_for_docker() {
     // Run a mock container in the background
     let mut mock_process = std::process::Command::new("docker")
-        .args(["run", "-d", "--name", "test", "--rm", "-p", "8081:80", "nginx:latest"])
+        .args([
+            "run",
+            "-d",
+            "--name",
+            "test",
+            "--rm",
+            "-p",
+            "8081:80",
+            "nginx:latest",
+        ])
         .spawn()
         .expect("Failed to run the mock container process");
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -76,7 +76,7 @@ fn test_killport_for_docker() {
             "run",
             "-d",
             "--name",
-            "test",
+            "for-killport-test",
             "--rm",
             "-p",
             "8081:80",

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,7 @@
 use assert_cmd::Command;
 use std::fs::File;
 use std::io::Write;
+use std::{thread, time};
 use tempfile::tempdir;
 
 #[test]
@@ -76,7 +77,7 @@ fn test_killport_for_docker() {
             "run",
             "-d",
             "--name",
-            "for-killport-test",
+            "test",
             "--rm",
             "-p",
             "8081:80",
@@ -84,6 +85,10 @@ fn test_killport_for_docker() {
         ])
         .spawn()
         .expect("Failed to run the mock container process");
+
+    // FIXME: We should wait a few millseconds for the container is running definitely.
+    let wait = time::Duration::from_millis(500);
+    thread::sleep(wait);
 
     // Test killport command with specifying a port is bound for docker container
     let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");


### PR DESCRIPTION
**Description of the changes**
1. Additional support to stop docker containers by specifying port number.
  - add `Killable` trait for abstraction layer to implement stopping native processes and docker containers.
  - Maybe we should relocate this trait to more upper hierarchy for implement stopping logics abstractly to all platforms.

2. Add some libraries
  - `anyhow`・・・ for easier generic error handling
  - `bollard`・・・for docker client in rust
  - `tokio`・・・for asynchronous runtime (because the `bollard` is only supported tokio runtime currently)

Sorry for some huge changes. 🙏

**Related issue(s)**
If this PR is related to an existing issue, please link to it using the `Fixes #issue_number` or `Closes #issue_number` syntax.

**Type of change**
Please select one or multiple of the following options:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code cleanup (refactoring or improving code quality)
- [ ] Documentation update (adding or updating documentation, updating README)

**Checklist:**
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Additional information**
Add any other information or screenshots about the pull request here.
