### PR TITLE
Support for remaining signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
 
 [[package]]
 name = "killport"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "assert_cmd",
  "cargo-deb",

--- a/README.md
+++ b/README.md
@@ -68,6 +68,41 @@ Kill processes with specified signal:
 killport -s sigkill 8080
 ```
 
+Supported Signals:
+- sighup
+- sigint
+- sigquit
+- sigill
+- sigtrap
+- sigabrt
+- sigbus
+- sigfpe
+- sigkill
+- sigusr1
+- sigsegv
+- sigusr2
+- sigpipe
+- sigalrm
+- sigterm
+- sigstkflt
+- sigchld
+- sigcont
+- sigstop
+- sigtstp
+- sigttin
+- sigttou
+- sigurg
+- sigxcpu
+- sigxfsz
+- sigvtalrm
+- sigprof
+- sigwinch
+- sigio
+- sigpwr
+- sigsys
+- sigemt
+- siginfo
+
 ### Flags
 
 -s, --signal

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -103,10 +103,7 @@ fn find_target_inodes(port: u16) -> Vec<u64> {
 ///
 /// * `target_inode` - A u64 value representing the target inode.
 /// * `signal` - A enum value representing the signal type.
-fn kill_processes_by_inode(
-    target_inode: u64,
-    signal: Signal,
-) -> Result<bool, Error> {
+fn kill_processes_by_inode(target_inode: u64, signal: Signal) -> Result<bool, Error> {
     let processes = procfs::process::all_processes().unwrap();
     let mut killed_any = false;
 
@@ -160,10 +157,7 @@ fn kill_processes_by_inode(
 ///
 /// * `pid` - An i32 value representing the process ID.
 /// * `signal` - A enum value representing the signal type.
-fn kill_process_and_children(
-    pid: i32,
-    signal: Signal,
-) -> Result<(), std::io::Error> {
+fn kill_process_and_children(pid: i32, signal: Signal) -> Result<(), std::io::Error> {
     let mut children_pids = Vec::new();
     collect_child_pids(pid, &mut children_pids)?;
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,5 +1,3 @@
-use crate::KillPortSignalOptions;
-
 use libproc::libproc::file_info::pidfdinfo;
 use libproc::libproc::file_info::{ListFDs, ProcFDType};
 use libproc::libproc::net_info::{SocketFDInfo, SocketInfoKind};
@@ -41,7 +39,7 @@ fn collect_proc() -> Vec<TaskAllInfo> {
 /// # Returns
 ///
 /// A `Result` containing a boolean value. If true, at least one process was killed; otherwise, false.
-pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Result<bool, io::Error> {
+pub fn kill_processes_by_port(port: u16, signal: Signal) -> Result<bool, io::Error> {
     let process_infos = collect_proc();
     let mut killed = false;
 
@@ -93,11 +91,7 @@ pub fn kill_processes_by_port(port: u16, signal: KillPortSignalOptions) -> Resul
                 warn!("Warning: Found Docker. You might need to stop the container manually.");
             } else {
                 info!("Killing process with PID {}", pid);
-                let system_signal = match signal {
-                    KillPortSignalOptions::SIGKILL => Signal::SIGKILL,
-                    KillPortSignalOptions::SIGTERM => Signal::SIGTERM,
-                };
-                match signal::kill(pid, system_signal) {
+                match signal::kill(pid, signal) {
                     Ok(_) => {
                         killed = true;
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,9 +54,9 @@ fn parse_signal(arg: &str) -> Result<Signal, std::io::Error> {
         Ok(str_arg) => {
             let signal_str = str_arg.to_uppercase();
             let signal = Signal::from_str(signal_str.as_str())?;
-            return Ok(signal)
-        },
-        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e))
+            return Ok(signal);
+        }
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e)),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,19 +14,12 @@ use linux::kill_processes_by_port;
 #[cfg(target_os = "macos")]
 use macos::kill_processes_by_port;
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use clap_verbosity_flag::{Verbosity, WarnLevel};
 use log::error;
-use std::process::exit;
+use nix::sys::signal::Signal;
+use std::{process::exit, str::FromStr};
 
-/// The `KillPortSignalOptions` enum is used to specify signal types on the command-line arguments.
-#[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum KillPortSignalOptions {
-    SIGKILL,
-    SIGTERM,
-}
-
-/// The `KillPortArgs` struct is used to parse command-line arguments for the
 /// `killport` utility.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -45,13 +38,26 @@ struct KillPortArgs {
         short = 's',
         name = "SIG",
         help = "SIG is a signal name",
-        default_value = "sigterm"
+        default_value = "sigterm",
+        value_parser = parse_signal
     )]
-    signal: KillPortSignalOptions,
+    signal: Signal,
 
     /// A verbosity flag to control the level of logging output.
     #[command(flatten)]
     verbose: Verbosity<WarnLevel>,
+}
+
+fn parse_signal(arg: &str) -> Result<Signal, std::io::Error> {
+    let str_arg = arg.parse::<String>();
+    match str_arg {
+        Ok(str_arg) => {
+            let signal_str = str_arg.to_uppercase();
+            let signal = Signal::from_str(signal_str.as_str())?;
+            return Ok(signal)
+        },
+        Err(e) => Err(std::io::Error::new(std::io::ErrorKind::Other, e))
+    }
 }
 
 /// The `main` function is the entry point of the `killport` utility.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,6 @@
 use assert_cmd::Command;
-use std::{fs::File, path};
 use std::io::Write;
+use std::{fs::File, path};
 use tempfile::tempdir;
 
 #[test]
@@ -45,10 +45,15 @@ fn test_killport() {
     // Software termination signal from kill
     test_killport_signal_arg(tempdir_path, "sigterm");
     // Stack fault (obsolete)
-    #[cfg(all(any(target_os = "android", target_os = "emscripten",
-                  target_os = "fuchsia", target_os = "linux"),
-              not(any(target_arch = "mips", target_arch = "mips64",
-                      target_arch = "sparc64"))))]
+    #[cfg(all(
+        any(
+            target_os = "android",
+            target_os = "emscripten",
+            target_os = "fuchsia",
+            target_os = "linux"
+        ),
+        not(any(target_arch = "mips", target_arch = "mips64", target_arch = "sparc64"))
+    ))]
     test_killport_signal_arg(tempdir_path, "sigstkflt");
     // To parent on child stop or exit
     test_killport_signal_arg(tempdir_path, "sigchld");
@@ -78,22 +83,36 @@ fn test_killport() {
     #[cfg(not(target_os = "haiku"))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     test_killport_signal_arg(tempdir_path, "sigio");
-    #[cfg(any(target_os = "android", target_os = "emscripten",
-              target_os = "fuchsia", target_os = "linux"))]
+    #[cfg(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "linux"
+    ))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     // Power failure imminent.
     test_killport_signal_arg(tempdir_path, "sigpwr");
     // Bad system call
     test_killport_signal_arg(tempdir_path, "sigsys");
-    #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                  target_os = "fuchsia", target_os = "linux",
-                  target_os = "redox", target_os = "haiku")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "redox",
+        target_os = "haiku"
+    )))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     // Emulator trap
     test_killport_signal_arg(tempdir_path, "sigemt");
-    #[cfg(not(any(target_os = "android", target_os = "emscripten",
-                  target_os = "fuchsia", target_os = "linux",
-                  target_os = "redox", target_os = "haiku")))]
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "emscripten",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "redox",
+        target_os = "haiku"
+    )))]
     #[cfg_attr(docsrs, doc(cfg(all())))]
     // Information request
     test_killport_signal_arg(tempdir_path, "siginfo");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,5 +1,5 @@
 use assert_cmd::Command;
-use std::fs::File;
+use std::{fs::File, path};
 use std::io::Write;
 use tempfile::tempdir;
 
@@ -8,7 +8,132 @@ fn test_killport() {
     // Create a temporary directory for testing.
     let tempdir = tempdir().expect("Failed to create temporary directory");
     let tempdir_path = tempdir.path();
+    generate_temp_process(tempdir_path);
 
+    // Test killport execution without options
+    test_killport_noargs(tempdir_path);
+
+    // Test killport execution with -s option
+    // Hangup
+    test_killport_signal_arg(tempdir_path, "sighup");
+    // Interrupt
+    test_killport_signal_arg(tempdir_path, "sigint");
+    // Quit
+    test_killport_signal_arg(tempdir_path, "sigquit");
+    // Illegal instruction (not reset when caught)
+    test_killport_signal_arg(tempdir_path, "sigill");
+    // Trace trap (not reset when caught)
+    test_killport_signal_arg(tempdir_path, "sigtrap");
+    // Abort
+    test_killport_signal_arg(tempdir_path, "sigabrt");
+    // Bus error
+    test_killport_signal_arg(tempdir_path, "sigbus");
+    // Floating point exception
+    test_killport_signal_arg(tempdir_path, "sigfpe");
+    // Kill (cannot be caught or ignored)
+    test_killport_signal_arg(tempdir_path, "sigkill");
+    // User defined signal 1
+    test_killport_signal_arg(tempdir_path, "sigusr1");
+    // Segmentation violation
+    test_killport_signal_arg(tempdir_path, "sigsegv");
+    // User defined signal 2
+    test_killport_signal_arg(tempdir_path, "sigusr2");
+    // Write on a pipe with no one to read it
+    test_killport_signal_arg(tempdir_path, "sigpipe");
+    // Alarm clock
+    test_killport_signal_arg(tempdir_path, "sigalrm");
+    // Software termination signal from kill
+    test_killport_signal_arg(tempdir_path, "sigterm");
+    // Stack fault (obsolete)
+    #[cfg(all(any(target_os = "android", target_os = "emscripten",
+                  target_os = "fuchsia", target_os = "linux"),
+              not(any(target_arch = "mips", target_arch = "mips64",
+                      target_arch = "sparc64"))))]
+    test_killport_signal_arg(tempdir_path, "sigstkflt");
+    // To parent on child stop or exit
+    test_killport_signal_arg(tempdir_path, "sigchld");
+    // Continue a stopped process
+    test_killport_signal_arg(tempdir_path, "sigcont");
+    // Sendable stop signal not from tty
+    test_killport_signal_arg(tempdir_path, "sigstop");
+    // Stop signal from tty
+    test_killport_signal_arg(tempdir_path, "sigtstp");
+    // To readers pgrp upon background tty read
+    test_killport_signal_arg(tempdir_path, "sigttin");
+    // Like TTIN if (tp->t_local&LTOSTOP)
+    test_killport_signal_arg(tempdir_path, "sigttou");
+    // Urgent condition on IO channel
+    test_killport_signal_arg(tempdir_path, "sigurg");
+    // Exceeded CPU time limit
+    test_killport_signal_arg(tempdir_path, "sigxcpu");
+    // Exceeded file size limit
+    test_killport_signal_arg(tempdir_path, "sigxfsz");
+    // Virtual time alarm
+    test_killport_signal_arg(tempdir_path, "sigvtalrm");
+    // Profiling time alarm
+    test_killport_signal_arg(tempdir_path, "sigprof");
+    // Window size changes
+    test_killport_signal_arg(tempdir_path, "sigwinch");
+    // Input/output possible signal
+    #[cfg(not(target_os = "haiku"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    test_killport_signal_arg(tempdir_path, "sigio");
+    #[cfg(any(target_os = "android", target_os = "emscripten",
+              target_os = "fuchsia", target_os = "linux"))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    // Power failure imminent.
+    test_killport_signal_arg(tempdir_path, "sigpwr");
+    // Bad system call
+    test_killport_signal_arg(tempdir_path, "sigsys");
+    #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                  target_os = "fuchsia", target_os = "linux",
+                  target_os = "redox", target_os = "haiku")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    // Emulator trap
+    test_killport_signal_arg(tempdir_path, "sigemt");
+    #[cfg(not(any(target_os = "android", target_os = "emscripten",
+                  target_os = "fuchsia", target_os = "linux",
+                  target_os = "redox", target_os = "haiku")))]
+    #[cfg_attr(docsrs, doc(cfg(all())))]
+    // Information request
+    test_killport_signal_arg(tempdir_path, "siginfo");
+}
+
+fn test_killport_signal_arg(tempdir_path: &path::Path, signal: &str) {
+    let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
+        .spawn()
+        .expect("Failed to run the mock process");
+
+    // Test killport command with specifying a signal name
+    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
+    cmd.arg("8080")
+        .arg("-s")
+        .arg(signal)
+        .assert()
+        .success()
+        .stdout("Successfully killed process listening on port 8080\n");
+
+    // Cleanup: Terminate the mock process (if still running).
+    let _ = mock_process.kill();
+}
+
+fn test_killport_noargs(tempdir_path: &path::Path) {
+    let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
+        .spawn()
+        .expect("Failed to run the mock process");
+
+    // Test killport command
+    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
+    cmd.arg("8080")
+        .assert()
+        .success()
+        .stdout("Successfully killed process listening on port 8080\n");
+
+    // Cleanup: Terminate the mock process (if still running).
+    let _ = mock_process.kill();
+}
+
+fn generate_temp_process(tempdir_path: &path::Path) {
     // Create a mock process that listens on a port.
     let mock_process = format!(
         r#"
@@ -34,36 +159,4 @@ fn test_killport() {
         .expect("Failed to compile mock_process.rs");
 
     assert!(status.success(), "Mock process compilation failed");
-
-    // Test killport execution without options
-    let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
-        .spawn()
-        .expect("Failed to run the mock process");
-
-    // Test killport command
-    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
-    cmd.arg("8080")
-        .assert()
-        .success()
-        .stdout("Successfully killed process listening on port 8080\n");
-
-    // Cleanup: Terminate the mock process (if still running).
-    let _ = mock_process.kill();
-
-    // Test killport execution with -s option
-    let mut mock_process = std::process::Command::new(tempdir_path.join("mock_process"))
-        .spawn()
-        .expect("Failed to run the mock process");
-
-    // Test killport command with specifying a signal name
-    let mut cmd = Command::cargo_bin("killport").expect("Failed to find killport binary");
-    cmd.arg("8080")
-        .arg("-s")
-        .arg("sigterm")
-        .assert()
-        .success()
-        .stdout("Successfully killed process listening on port 8080\n");
-
-    // Cleanup: Terminate the mock process (if still running).
-    let _ = mock_process.kill();
 }


### PR DESCRIPTION
**Description of the changes**
- Adds support to send all signals available in `nix::sys::signal::Signal` and works with the same `-s` option.
- Refactored `integration_test.rs`

**Related issue(s)**
Improves on #8 

**Type of change**
Please select one or multiple of the following options:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code cleanup (refactoring or improving code quality)
- [ ] Documentation update (adding or updating documentation, updating README)

**Checklist:**
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
